### PR TITLE
Use semantic elements for header title and tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,9 @@
   .note-logo{width:34px; height:34px; border-radius:12px; background: conic-gradient(from 200deg at 50% 50%, var(--brand-2), var(--brand-1), var(--brand-3)); display:grid; place-items:center; box-shadow:0 6px 18px rgba(0,0,0,.25)}
   .note-logo svg{filter:drop-shadow(0 2px 0 rgba(0,0,0,.2))}
 
+  header .site-title{font-size:20px; font-weight:900; line-height:1}
+  header .tagline{font-size:12px; opacity:.75}
+
   main{max-width:1200px; margin:18px auto; padding:0 16px}
 
   /* Tabs */
@@ -151,8 +154,8 @@
         </svg>
       </div>
       <div>
-        <div style="font-size:20px; font-weight:900; line-height:1">Music Theory Trainer</div>
-        <div style="font-size:12px; opacity:.75">Learn notes, scales, chords — and train your ear 🎵</div>
+        <h1 class="site-title">Music Theory Trainer</h1>
+        <p class="tagline">Learn notes, scales, chords — and train your ear 🎵</p>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- replace header title div with `<h1>` and tagline div with `<p>`
- move inline styles into `.site-title` and `.tagline` classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e0f5dff083319f04b22f2fcd295f